### PR TITLE
Make header bubbles respond to route changes

### DIFF
--- a/GearPatch/client/src/components/Header.js
+++ b/GearPatch/client/src/components/Header.js
@@ -1,5 +1,5 @@
 import React, { useState, useContext, useEffect } from "react";
-import { useHistory, NavLink as RRNavLink } from "react-router-dom";
+import { useHistory, useLocation, NavLink as RRNavLink } from "react-router-dom";
 import Login from "./Users/Login";
 import { Navbar, Dropdown, DropdownToggle, DropdownMenu, DropdownItem, NavbarBrand, NavbarToggler,
     Collapse, Nav, NavItem, NavLink, Badge, Button } from "reactstrap";
@@ -22,6 +22,7 @@ export default function Header() {
     const headerToggle = () => setDropdownOpen(!dropdownOpen);
 
     const history = useHistory();
+    const location = useLocation();
 
     const newItemButton = (evt) => {
         evt.preventDefault();
@@ -38,7 +39,7 @@ export default function Header() {
             getUnconfirmed();
         }
         // eslint-disable-next-line
-    }, [isLoggedIn])
+    }, [isLoggedIn, location])
 
     return (
         <header>

--- a/GearPatch/client/src/components/Messages/ReservationAutoMessages.js
+++ b/GearPatch/client/src/components/Messages/ReservationAutoMessages.js
@@ -33,7 +33,7 @@ export function ConfirmReservationMessage(reservation) {
 export function CancelReservationMessage(currentUser, otherUser, reservation) {
 
     const messageText = `${currentUser.fullName} has CANCELED your reservation for ${reservation.gear.manufacturer} ${reservation.gear.model} from ${reservation.startDate} to ${reservation.endDate}.
-    Please contact ${otherUser.fullName} with any questions and to make arrangements for pick up and drop off.`
+    Please contact ${currentUser.fullName} with any questions or to request alternate arrangements.`
 
     return {
         recipientId: otherUser.id,


### PR DESCRIPTION
Made the header bubble rendering depending upon location via ```useLocation()```.  This ensures any changes to the count of the message and reservation bubbles update when the page (route) changes.

Also caught and fixed wording on the automated message for a reservation cancellation.